### PR TITLE
ci: push releases to stable branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+name-template: ComPWA Organization Documentation $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
+
+references:
+  - main
+  - epic/*
+
+categories:
+  - title: 💡 New features
+    label: 💡 Feature
+  - title: ⚠️ Interface
+    label: ⚠️ Interface
+  - title: 🐛 Bug fixes
+    label: Bug
+  - title: 🔨 Internal maintenance
+    label: 🔨 Maintenance
+  - title: 📝 Documentation
+    label: 📝 Docs
+  - title: 🖱️ Developer Experience
+    label: 🖱️ DX
+
+change-template: |
+  <details>
+  <summary>$TITLE (#$NUMBER)</summary>
+
+  $BODY
+
+  </details>
+
+replacers:
+  - search: /<summary>([a-z]+!?:\s*)(.*)</summary>/g
+    replace: <summary>$2</summary>
+
+sort-direction: ascending
+
+template: |
+  # Release $NEXT_PATCH_VERSION
+
+  See all documentation for this version [here](https://compwa-org.rtfd.io/en/$NEXT_PATCH_VERSION).
+
+  $CHANGES

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,22 @@
+# cspell:ignore noreply prereleased
+
+name: CD
+
+on:
+  release:
+    types:
+      - prereleased
+      - released
+
+jobs:
+  push:
+    name: Push to stable branch
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Push to stable branch
+        run: |
+          git config --global user.name "GitHub Action"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git push origin HEAD:refs/heads/stable -f

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+      - epic/*
+  workflow_dispatch:
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,7 +193,7 @@ for root, _, files in os.walk("../demo"):
             break
         if not notebook_title:
             raise ValueError(f'Notebook "{filepath}" does not have a title')
-        link = f"https://mybinder.org/v2/gh/ComPWA/compwa-org/main?urlpath=apps%2Fdemo%2F{filename}"
+        link = f"https://mybinder.org/v2/gh/ComPWA/compwa-org/stable?urlpath=apps%2Fdemo%2F{filename}"
         demo_template += f"{notebook_title} <{link}>\n"
 demo_template += "```\n"
 


### PR DESCRIPTION
For Binder it's important to have changes in the stable branch to often. This construct of stable/latest (as in ampform, qrules, etc.) helps providing a more stable binder.