### PR TITLE
docs: distinguish appmode and normal presentations

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,28 @@
+# Demonstration of ComPWA software packages
+
+The following Jupyter notebooks are hosted as interactive presentations on
+[compwa-org.rtfd.io/en/stable/demo.html](https://compwa-org.readthedocs.io/en/stable/demo.html)
+and illustrates what the
+[several packages by the ComPWA organization](https://pwa.readthedocs.io/software.html#affiliated-projects)
+have to offer.
+
+As opposed to
+[Technical Reports](https://compwa-org.readthedocs.io/en/stable/reports.html)
+and [ADRs](https://compwa-org.readthedocs.io/en/stable/adr.html), these
+notebooks should work for the latest releases of all ComPWA packages.
+
+There are two types of notebooks:
+
+1. [Interactive apps](https://github.com/binder-examples/appmode). These run
+   all cells directly when the notebook is launched, but _do not show input
+   cells_.
+
+2. Normal [Jupyter RISE](https://github.com/binder-examples/jupyter-rise)
+   demos. In these notebooks, input cells can be made visible, but the visitors
+   have to run all cells themselves.
+
+To activate 1., add a Markdown cell with the following comment:
+
+```markdown
+<!-- app-mode -->
+```

--- a/demo/analytic-continuation.ipynb
+++ b/demo/analytic-continuation.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<!-- app-mode-->"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,9 +185,15 @@ for root, _, files in os.walk("../demo"):
         filepath = os.path.join(root, filename)
         notebook = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
         notebook_title = ""
+        app_mode = False
         for cell in notebook.cells:
             if not cell.cell_type == "markdown":
                 continue
+            if not app_mode and (
+                "<!-- appmode -->" in cell.source
+                or "<!-- app-mode -->" in cell.source
+            ):
+                app_mode = True
             if not cell.source.startswith("# "):
                 continue
             notebook_title = cell.source
@@ -196,7 +202,11 @@ for root, _, files in os.walk("../demo"):
             break
         if not notebook_title:
             raise ValueError(f'Notebook "{filepath}" does not have a title')
-        link = f"https://mybinder.org/v2/gh/ComPWA/compwa-org/stable?urlpath=apps%2Fdemo%2F{filename}"
+        link = "https://mybinder.org/v2/gh/ComPWA/compwa-org/stable"
+        if app_mode:
+            link += f"?urlpath=apps%2Fdemo%2F{filename}"
+        else:
+            link += f"?filepath=demo%2F{filename}"
         demo_template += f"{notebook_title} <{link}>\n"
 demo_template += "```\n"
 


### PR DESCRIPTION
Add demos as [appmode](https://github.com/binder-examples/appmode) or a normal Jupyter notebook by adding a Markdown comment.