### PR TITLE
docs: improve analytic continuation with split cells

### DIFF
--- a/demo/ampform.ipynb
+++ b/demo/ampform.ipynb
@@ -198,7 +198,7 @@
     "ComPWA provides an _ecosystem_ of three Python packages:\n",
     "1. `QRules`: quantum number conservation rules ('resonance finder')\n",
     "2. `AmpForm`: spin formalisms and dynamics\n",
-    "3. `TensorWaves`: toy MC and model optimization with multiple computational back-ends"
+    "3. `TensorWaves`: toy MC and model optimization"
    ]
   },
   {
@@ -418,7 +418,7 @@
     "tags": []
    },
    "source": [
-    "...and after substituting the suggested parameter values suggested by `AmpForm`:"
+    "...and after substituting the parameter values suggested by `AmpForm`:"
    ]
   },
   {

--- a/demo/analytic-continuation.ipynb
+++ b/demo/analytic-continuation.ipynb
@@ -29,6 +29,7 @@
    },
    "outputs": [],
    "source": [
+    "%config InlineBackend.figure_formats = ['svg']\n",
     "%matplotlib widget\n",
     "import logging\n",
     "import warnings\n",
@@ -840,16 +841,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "cell_style": "split",
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Main questions\n",
+    "\n",
+    "Analytic continuation ($\\color{red}{\\rho}$):\n",
+    "- Does analytic continuation in a Breit-Wigner <br>make sense at all?\n",
+    "- Are the two 'bumps' when below threshold desired?\n",
+    "- What happened to the 'case-wise' analytic continuation? <br>[[PDG2018, §Resonances, p.9](https://pdg.lbl.gov/2018/reviews/rpp2018-rev-resonances.pdf#page=9)]\n",
+    "\n",
+    "Relativistic Breit-Wigner with form factor ($\\color{blue}{B_L}$):\n",
+    "- What to do with the damping factor below threshold?"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "cell_style": "split",
     "hideCode": true,
     "hidePrompt": false,
     "jupyter": {
      "source_hidden": true
     },
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "-"
     },
     "tags": []
    },
@@ -925,8 +948,8 @@
     "fig, all_axes = plt.subplots(\n",
     "    nrows=3,\n",
     "    ncols=2,\n",
-    "    figsize=(10, 8),\n",
-    "    gridspec_kw={\"width_ratios\": [2.5, 1]},\n",
+    "    figsize=(8, 8),\n",
+    "    gridspec_kw={\"width_ratios\": [1.8, 1]},\n",
     ")\n",
     "fig.suptitle(\"Relativistic Breit-Wigners with different phase space factors\")\n",
     "fig.canvas.toolbar_visible = False\n",

--- a/demo/analytic-continuation.ipynb
+++ b/demo/analytic-continuation.ipynb
@@ -49,7 +49,7 @@
     "    relativistic_breit_wigner_with_ff,\n",
     ")\n",
     "from ampform.dynamics.math import ComplexSqrt\n",
-    "from IPython.display import Math\n",
+    "from IPython.display import HTML, Math\n",
     "from ipywidgets import widgets\n",
     "\n",
     "logging.basicConfig()\n",
@@ -57,25 +57,15 @@
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
-    "np.seterr(divide=\"ignore\");"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hideCode": true,
-    "slideshow": {
-     "slide_type": "skip"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%HTML\n",
+    "np.seterr(divide=\"ignore\")\n",
+    "\n",
+    "HTML(\n",
+    "    \"\"\"\n",
     "<style>\n",
     "div.prompt {display:none}\n",
-    "</style>"
+    "</style>\n",
+    "\"\"\"\n",
+    ")"
    ]
   },
   {
@@ -96,9 +86,6 @@
    "metadata": {
     "hideCode": true,
     "hidePrompt": false,
-    "jupyter": {
-     "source_hidden": true
-    },
     "slideshow": {
      "slide_type": "skip"
     },
@@ -205,7 +192,7 @@
     "rel_bw_with_ff_subs = rel_bw_with_ff.subs(\n",
     "    {\n",
     "        2 * q_squared: 2 * sp.Symbol(\"q^{2}(m)\"),\n",
-    "        ff_sq: sp.Symbol(R\"B_{L}^{2}\\left(q\\right)\"),\n",
+    "        ff_sq: sp.Symbol(R\"\\color{blue}{B_{L}^{2}\\left(q\\right)}\"),\n",
     "        running_width: sp.Symbol(R\"\\Gamma(m)\"),\n",
     "    }\n",
     ")\n",
@@ -244,7 +231,9 @@
     "rho0 = phase_space_factor(m0 ** 2, m_a, m_b)\n",
     "running_width = running_width.subs(\n",
     "    {\n",
-    "        rho / rho0: sp.Symbol(R\"\\rho(m)\") / sp.Symbol(R\"\\rho(m_{0})\"),\n",
+    "        rho\n",
+    "        / rho0: sp.Symbol(R\"\\color{red}{\\rho(m)}\")\n",
+    "        / sp.Symbol(R\"\\color{red}{\\rho(m_{0})}\"),\n",
     "        ff_sq: sp.Symbol(\"B_{L}^{2}(q)\"),\n",
     "        ff0_sq: sp.Symbol(\"B_{L}^{2}(q_{0})\"),\n",
     "    },\n",
@@ -275,7 +264,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have to choose a phase space factor $\\rho$ for the coupled width:"
+    "We have to choose a phase space factor $\\color{red}{\\rho}$ for the coupled width:"
    ]
   },
   {
@@ -393,7 +382,7 @@
     }
    },
    "source": [
-    "**Analytic continuation** of the phase space factor [[PDG2016, §Resonances, p.9](https://pdg.lbl.gov/2016/reviews/rpp2016-rev-resonances.pdf#page=9)] (<span style=\"color:red\">only valid if $m_a = m_b$ (?)</span>):"
+    "**Analytic continuation** of the phase space factor [[PDG2018, §Resonances, p.9](https://pdg.lbl.gov/2018/reviews/rpp2018-rev-resonances.pdf#page=9)] (<span style=\"color:red\">only valid if $m_a = m_b$ (?)</span>):"
    ]
   },
   {

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,8 @@
 #!/bin/bash
-# cspell:ignore nbextension serverextension
+# cspell:ignore nbextension serverextension splitcell
 set -e
+jupyter contrib nbextension install --user
 jupyter nbextension install --py hide_code --user
 jupyter nbextension enable --py hide_code --user
+jupyter nbextension enable splitcell/splitcell --user
 jupyter serverextension enable --py hide_code --user

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ dev =
     %(sty)s
     %(test)s
     hide_code
+    jupyter_contrib_nbextensions
     jupyter_nbextensions_configurator
     jupyterlab >= 3.0.0
     jupyterlab-code-formatter


### PR DESCRIPTION
Added a summary slide to the analytic continuation demo, using [splitcell](https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/splitcell/readme.html).