### PR TITLE
ci: speed up TR-009 and TR-010

### DIFF
--- a/docs/report/009.ipynb
+++ b/docs/report/009.ipynb
@@ -809,6 +809,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if STATIC_WEB_PAGE:\n",
+    "    L = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": []
    },
    "outputs": [],

--- a/docs/report/010.ipynb
+++ b/docs/report/010.ipynb
@@ -646,6 +646,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "if STATIC_WEB_PAGE:\n",
+    "    L = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": []
    },
    "outputs": [],


### PR DESCRIPTION
Remove the angular momentum slider when executing the notebook on RTD. If angular momentum is lambdified as well, the lambdified expression becomes huge and it can take half a minute to create.