### PR TITLE
fix: add back hide-code extension

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -6,7 +6,7 @@
 #
 absl-py==0.14.0
 alabaster==0.7.12
-ampform==0.11.2
+ampform==0.11.3
 anyio==3.3.2
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
@@ -42,7 +42,7 @@ dm-tree==0.1.6
 docutils==0.16
 entrypoints==0.3
 execnet==1.9.0
-filelock==3.0.12
+filelock==3.1.0
 flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.1
@@ -63,9 +63,10 @@ google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.1
-grpcio==1.40.0
+grpcio==1.41.0
 h5py==3.1.0
 hepunits==2.1.1
+hide-code==0.6.0
 identify==2.2.15
 idna==3.2
 imagesize==1.2.0
@@ -99,7 +100,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.0
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.13
+jupyterlab==3.1.14
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -139,6 +140,7 @@ pandocfilters==1.5.0
 parso==0.8.2
 particle==0.16.1
 pathspec==0.9.0
+pdfkit==0.6.1
 pep517==0.11.0
 pep8-naming==0.12.1
 pexpect==4.8.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -6,7 +6,7 @@
 #
 absl-py==0.14.0
 alabaster==0.7.12
-ampform==0.11.2
+ampform==0.11.3
 anyio==3.3.2
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
@@ -41,7 +41,7 @@ dm-tree==0.1.6
 docutils==0.16
 entrypoints==0.3
 execnet==1.9.0
-filelock==3.0.12
+filelock==3.1.0
 flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.1
@@ -62,9 +62,10 @@ google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.1
-grpcio==1.40.0
+grpcio==1.41.0
 h5py==3.1.0
 hepunits==2.1.1
+hide-code==0.6.0
 identify==2.2.15
 idna==3.2
 imagesize==1.2.0
@@ -97,7 +98,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.0
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.13
+jupyterlab==3.1.14
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -138,6 +139,7 @@ pandocfilters==1.5.0
 parso==0.8.2
 particle==0.16.1
 pathspec==0.9.0
+pdfkit==0.6.1
 pep517==0.11.0
 pep8-naming==0.12.1
 pexpect==4.8.0
@@ -225,7 +227,7 @@ tomli==1.2.1
 tornado==6.1
 tox==3.24.4
 tqdm==4.62.3
-traitlets==5.1.0
+traitlets==4.3.3
 typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.7

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -6,7 +6,7 @@
 #
 absl-py==0.14.0
 alabaster==0.7.12
-ampform==0.11.2
+ampform==0.11.3
 anyio==3.3.2
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
@@ -39,7 +39,7 @@ dm-tree==0.1.6
 docutils==0.16
 entrypoints==0.3
 execnet==1.9.0
-filelock==3.0.12
+filelock==3.1.0
 flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.1
@@ -60,9 +60,10 @@ google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.1
-grpcio==1.40.0
+grpcio==1.41.0
 h5py==3.1.0
 hepunits==2.1.1
+hide-code==0.6.0
 identify==2.2.15
 idna==3.2
 imagesize==1.2.0
@@ -95,7 +96,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.0
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.13
+jupyterlab==3.1.14
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -136,6 +137,7 @@ pandocfilters==1.5.0
 parso==0.8.2
 particle==0.16.1
 pathspec==0.9.0
+pdfkit==0.6.1
 pep517==0.11.0
 pep8-naming==0.12.1
 pexpect==4.8.0
@@ -223,7 +225,7 @@ tomli==1.2.1
 tornado==6.1
 tox==3.24.4
 tqdm==4.62.3
-traitlets==5.1.0
+traitlets==4.3.3
 typing-extensions==3.7.4.3
 urllib3==1.26.7
 virtualenv==20.8.1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -6,7 +6,7 @@
 #
 absl-py==0.14.0
 alabaster==0.7.12
-ampform==0.11.2
+ampform==0.11.3
 anyio==3.3.2
 appdirs==1.4.4
 aquirdturtle-collapsible-headings==3.1.0
@@ -39,7 +39,7 @@ dm-tree==0.1.6
 docutils==0.16
 entrypoints==0.3
 execnet==1.9.0
-filelock==3.0.12
+filelock==3.1.0
 flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.1
@@ -60,9 +60,10 @@ google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.1
-grpcio==1.40.0
+grpcio==1.41.0
 h5py==3.1.0
 hepunits==2.1.1
+hide-code==0.6.0
 identify==2.2.15
 idna==3.2
 imagesize==1.2.0
@@ -95,7 +96,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.0
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.13
+jupyterlab==3.1.14
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -136,6 +137,7 @@ pandocfilters==1.5.0
 parso==0.8.2
 particle==0.16.1
 pathspec==0.9.0
+pdfkit==0.6.1
 pep517==0.11.0
 pep8-naming==0.12.1
 pexpect==4.8.0
@@ -223,7 +225,7 @@ tomli==1.2.1
 tornado==6.1
 tox==3.24.4
 tqdm==4.62.3
-traitlets==5.1.0
+traitlets==4.3.3
 typing-extensions==3.7.4.3
 urllib3==1.26.7
 virtualenv==20.8.1

--- a/.github/workflows/requirements-cron.yml
+++ b/.github/workflows/requirements-cron.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Install pip-tools
         run: |
           python -m pip install --upgrade pip
-          pip install pip-tools
+          pip install pip-tools notebook
+        # notebook required because it is imported in hide-code's setup.py...
+        # https://github.com/kirbs-/hide_code/tree/v0.6.0/setup.py#L9
       - name: Upgrade pinned requirements
         run: python3 .constraints/pin_requirements.py
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/requirements-pr.yml
+++ b/.github/workflows/requirements-pr.yml
@@ -45,7 +45,9 @@ jobs:
         if: steps.git-diff.outputs.dependency-changes != ''
         run: |
           python -m pip install --upgrade pip
-          pip install pip-tools
+          pip install pip-tools notebook
+        # notebook required because it is imported in hide-code's setup.py...
+        # https://github.com/kirbs-/hide_code/tree/v0.6.0/setup.py#L9
       - name: Upgrade dependencies
         if: steps.git-diff.outputs.dependency-changes != ''
         run: python3 .constraints/pin_requirements.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,6 @@ repos:
     rev: 0.0.41
     hooks:
       - id: check-dev-files
-        args:
-          - --pin-requirements
       - id: fix-nbformat-version
       - id: format-setup-cfg
       - id: pin-nb-requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ dev =
     %(sty)s
     %(test)s
     aquirdturtle_collapsible_headings
+    hide_code
     jupyter_contrib_nbextensions
     jupyter_nbextensions_configurator
     jupyterlab >=3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,10 +81,10 @@ dev =
     %(doc)s
     %(sty)s
     %(test)s
-    aquirdturtle_collapsible_headings
-    hide_code
-    jupyter_contrib_nbextensions
-    jupyter_nbextensions_configurator
+    aquirdturtle-collapsible-headings
+    hide-code
+    jupyter-contrib-nbextensions
+    jupyter-nbextensions-configurator
     jupyterlab >=3.0.0
     jupyterlab-code-formatter
     pip-tools >=6.1.0  # for extras_require


### PR DESCRIPTION
Closes #67 

`hide_code` was mistakenly removed in #58