### PR TITLE
docs: implement sphinx-issues extension

### DIFF
--- a/.constraints/py3.6.txt
+++ b/.constraints/py3.6.txt
@@ -24,9 +24,9 @@ bleach==4.1.0
 cached-property==1.5.2
 cachetools==4.2.4
 certifi==2021.10.8
-cffi==1.14.6
+cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
 clang==5.0
 click==7.1.2
 cloudpickle==2.0.0
@@ -47,7 +47,7 @@ flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.2
 flake8-builtins==1.5.3
-flake8-comprehensions==3.6.1
+flake8-comprehensions==3.7.0
 flake8-plugin-utils==1.3.2
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.5.0
@@ -58,17 +58,17 @@ future==0.18.2
 gast==0.4.0
 gitdb==4.0.7
 gitpython==3.1.18
-google-auth==1.35.0
+google-auth==2.3.0
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.2
 grpcio==1.41.0
 h5py==3.1.0
-hepunits==2.1.1
+hepunits==2.1.2
 hide-code==0.6.0
 identify==2.3.0
-idna==3.2
+idna==3.3
 imagesize==1.2.0
 iminuit==2.8.4
 immutables==0.16
@@ -100,7 +100,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.18
+jupyterlab==3.2.0
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -147,7 +147,7 @@ pexpect==4.8.0
 phasespace==1.4.1
 pickleshare==0.7.5
 pillow==8.3.2
-pip-tools==6.3.1
+pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.15.0
@@ -175,7 +175,7 @@ pytest-xdist==2.4.0
 python-constraint==1.4.0
 python-dateutil==2.8.2
 pytz==2021.3
-pyyaml==5.4.1
+pyyaml==6.0
 pyzmq==22.3.0
 qrules==0.9.2
 qtconsole==5.1.1
@@ -199,6 +199,7 @@ sphinx==4.2.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.1.5
 sphinx-copybutton==0.4.0
+sphinx-issues==1.2.0
 sphinx-math-dollar==1.2
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10
@@ -213,7 +214,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sqlalchemy==1.4.25
 sympy==1.9
-tensorboard==2.6.0
+tensorboard==2.7.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
 tensorflow==2.6.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -24,9 +24,9 @@ bleach==4.1.0
 cached-property==1.5.2
 cachetools==4.2.4
 certifi==2021.10.8
-cffi==1.14.6
+cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
 clang==5.0
 click==7.1.2
 cloudpickle==2.0.0
@@ -46,7 +46,7 @@ flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.2
 flake8-builtins==1.5.3
-flake8-comprehensions==3.6.1
+flake8-comprehensions==3.7.0
 flake8-plugin-utils==1.3.2
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.5.0
@@ -57,17 +57,17 @@ future==0.18.2
 gast==0.4.0
 gitdb==4.0.7
 gitpython==3.1.24
-google-auth==1.35.0
+google-auth==2.3.0
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.2
 grpcio==1.41.0
 h5py==3.1.0
-hepunits==2.1.1
+hepunits==2.1.2
 hide-code==0.6.0
 identify==2.3.0
-idna==3.2
+idna==3.3
 imagesize==1.2.0
 iminuit==2.8.4
 importlib-metadata==4.8.1
@@ -79,8 +79,8 @@ ipython==7.28.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.9.3
-jax==0.2.21
-jaxlib==0.1.71
+jax==0.2.22
+jaxlib==0.1.72
 jedi==0.18.0
 jinja2==3.0.2
 json5==0.9.6
@@ -98,7 +98,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.18
+jupyterlab==3.2.0
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -146,7 +146,7 @@ pexpect==4.8.0
 phasespace==1.4.1
 pickleshare==0.7.5
 pillow==8.3.2
-pip-tools==6.3.1
+pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.15.0
@@ -174,7 +174,7 @@ pytest-xdist==2.4.0
 python-constraint==1.4.0
 python-dateutil==2.8.2
 pytz==2021.3
-pyyaml==5.4.1
+pyyaml==6.0
 pyzmq==22.3.0
 qrules==0.9.2
 qtconsole==5.1.1
@@ -198,6 +198,7 @@ sphinx==4.2.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.1.5
 sphinx-copybutton==0.4.0
+sphinx-issues==1.2.0
 sphinx-math-dollar==1.2
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10
@@ -212,7 +213,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sqlalchemy==1.4.25
 sympy==1.9
-tensorboard==2.6.0
+tensorboard==2.7.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
 tensorflow==2.6.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -22,9 +22,9 @@ black==21.7b0
 bleach==4.1.0
 cachetools==4.2.4
 certifi==2021.10.8
-cffi==1.14.6
+cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
 clang==5.0
 click==7.1.2
 cloudpickle==2.0.0
@@ -44,7 +44,7 @@ flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.2
 flake8-builtins==1.5.3
-flake8-comprehensions==3.6.1
+flake8-comprehensions==3.7.0
 flake8-plugin-utils==1.3.2
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.5.0
@@ -55,17 +55,17 @@ future==0.18.2
 gast==0.4.0
 gitdb==4.0.7
 gitpython==3.1.24
-google-auth==1.35.0
+google-auth==2.3.0
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.2
 grpcio==1.41.0
 h5py==3.1.0
-hepunits==2.1.1
+hepunits==2.1.2
 hide-code==0.6.0
 identify==2.3.0
-idna==3.2
+idna==3.3
 imagesize==1.2.0
 iminuit==2.8.4
 importlib-metadata==4.8.1
@@ -77,8 +77,8 @@ ipython==7.28.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.9.3
-jax==0.2.21
-jaxlib==0.1.71
+jax==0.2.22
+jaxlib==0.1.72
 jedi==0.18.0
 jinja2==3.0.2
 json5==0.9.6
@@ -96,7 +96,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.18
+jupyterlab==3.2.0
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -144,7 +144,7 @@ pexpect==4.8.0
 phasespace==1.4.1
 pickleshare==0.7.5
 pillow==8.3.2
-pip-tools==6.3.1
+pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.15.0
@@ -172,7 +172,7 @@ pytest-xdist==2.4.0
 python-constraint==1.4.0
 python-dateutil==2.8.2
 pytz==2021.3
-pyyaml==5.4.1
+pyyaml==6.0
 pyzmq==22.3.0
 qrules==0.9.2
 qtconsole==5.1.1
@@ -196,6 +196,7 @@ sphinx==4.2.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.1.5
 sphinx-copybutton==0.4.0
+sphinx-issues==1.2.0
 sphinx-math-dollar==1.2
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10
@@ -210,7 +211,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sqlalchemy==1.4.25
 sympy==1.9
-tensorboard==2.6.0
+tensorboard==2.7.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
 tensorflow==2.6.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -22,9 +22,9 @@ black==21.7b0
 bleach==4.1.0
 cachetools==4.2.4
 certifi==2021.10.8
-cffi==1.14.6
+cffi==1.15.0
 cfgv==3.3.1
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
 clang==5.0
 click==7.1.2
 cloudpickle==2.0.0
@@ -44,7 +44,7 @@ flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-bugbear==21.9.2
 flake8-builtins==1.5.3
-flake8-comprehensions==3.6.1
+flake8-comprehensions==3.7.0
 flake8-plugin-utils==1.3.2
 flake8-polyfill==1.0.2
 flake8-pytest-style==1.5.0
@@ -55,17 +55,17 @@ future==0.18.2
 gast==0.4.0
 gitdb==4.0.7
 gitpython==3.1.24
-google-auth==1.35.0
+google-auth==2.3.0
 google-auth-oauthlib==0.4.6
 google-pasta==0.2.0
 graphviz==0.17
 greenlet==1.1.2
 grpcio==1.41.0
 h5py==3.1.0
-hepunits==2.1.1
+hepunits==2.1.2
 hide-code==0.6.0
 identify==2.3.0
-idna==3.2
+idna==3.3
 imagesize==1.2.0
 iminuit==2.8.4
 importlib-metadata==4.8.1
@@ -77,8 +77,8 @@ ipython==7.28.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.5
 isort==5.9.3
-jax==0.2.21
-jaxlib==0.1.71
+jax==0.2.22
+jaxlib==0.1.72
 jedi==0.18.0
 jinja2==3.0.2
 json5==0.9.6
@@ -96,7 +96,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-server==1.11.1
 jupyter-server-mathjax==0.2.3
 jupyter-sphinx==0.3.2
-jupyterlab==3.1.18
+jupyterlab==3.2.0
 jupyterlab-code-formatter==1.4.10
 jupyterlab-server==2.8.2
 jupyterlab-widgets==1.0.2
@@ -144,7 +144,7 @@ pexpect==4.8.0
 phasespace==1.4.1
 pickleshare==0.7.5
 pillow==8.3.2
-pip-tools==6.3.1
+pip-tools==6.4.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.15.0
@@ -172,7 +172,7 @@ pytest-xdist==2.4.0
 python-constraint==1.4.0
 python-dateutil==2.8.2
 pytz==2021.3
-pyyaml==5.4.1
+pyyaml==6.0
 pyzmq==22.3.0
 qrules==0.9.2
 qtconsole==5.1.1
@@ -196,6 +196,7 @@ sphinx==4.2.0
 sphinx-autobuild==2021.3.14
 sphinx-book-theme==0.1.5
 sphinx-copybutton==0.4.0
+sphinx-issues==1.2.0
 sphinx-math-dollar==1.2
 sphinx-panels==0.6.0
 sphinx-thebe==0.0.10
@@ -210,7 +211,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sqlalchemy==1.4.25
 sympy==1.9
-tensorboard==2.6.0
+tensorboard==2.7.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
 tensorflow==2.6.0

--- a/docs/adr/000.md
+++ b/docs/adr/000.md
@@ -7,11 +7,10 @@ Status: **accepted**
 Deciders: @redeboer, @spflueger
 
 Technical story: A large number of issues in the {mod}`expertsystem` are
-correlated (e.g. [#40](https://github.com/ComPWA/expertsystem/issues/40),
-[#44](https://github.com/ComPWA/expertsystem/issues/44),
-[#22](https://github.com/ComPWA/expertsystem/issues/22)) so that resulting PRs
-(in this case, [#42](https://github.com/ComPWA/expertsystem/pull/42)) lacked
-direction. This led us to consider ADRs.
+correlated (e.g. {issue}`ComPWA/expertsystem#40`,
+{issue}`ComPWA/expertsystem#44`, {issue}`ComPWA/expertsystem#22`) so that
+resulting PRs (in this case, {pr}`ComPWA/expertsystem#42`) lacked direction.
+This led us to consider ADRs.
 
 ## Context and Problem Statement
 

--- a/docs/adr/001.md
+++ b/docs/adr/001.md
@@ -22,23 +22,21 @@ requirements:
 
 ### Technical story
 
-- [#382](https://github.com/ComPWA/expertsystem/issues/382): Coupling
-  parameters in the `AmplitudeModel` is difficult (has to be done through the
-  place where they are used in the `dynamics` or `intensity` section) and
-  counter-intuitive (cannot be done through the `parameters` section)
-- [#440](https://github.com/ComPWA/expertsystem/issues/440): when overwriting
-  existing dynamics, old parameters are not cleaned up from the `parameters`
-  section
-- [#441](https://github.com/ComPWA/expertsystem/issues/441): parameters contain
-  a name that can be changed, but that results in a mismatch between the key
-  that is used in the `parameters` section and the name of the parameter to
-  which that entry points.
-- [ComPWA#226](https://github.com/ComPWA/ComPWA/issues/226): Use a math
-  language for the blueprint of the function. This was also discussed early to
-  mid 2020, but dropped in favor of custom python code + `amplitf`. The
-  reasoning was that the effort of writing some new math language plus
-  generators converting a mathematical expression into a function (using
-  various back-ends) requires too much manpower.
+- {issue}`ComPWA/expertsystem#382`: Coupling parameters in the `AmplitudeModel`
+  is difficult (has to be done through the place where they are used in the
+  `dynamics` or `intensity` section) and counter-intuitive (cannot be done
+  through the `parameters` section)
+- {issue}`ComPWA/expertsystem#440`: when overwriting existing dynamics, old
+  parameters are not cleaned up from the `parameters` section
+- {issue}`ComPWA/expertsystem#441`: parameters contain a name that can be
+  changed, but that results in a mismatch between the key that is used in the
+  `parameters` section and the name of the parameter to which that entry
+  points.
+- {pr}`ComPWA/ComPWA#226`: Use a math language for the blueprint of the
+  function. This was also discussed early to mid 2020, but dropped in favor of
+  custom python code + `amplitf`. The reasoning was that the effort of writing
+  some new math language plus generators converting a mathematical expression
+  into a function (using various back-ends) requires too much manpower.
 
 ## Decision drivers
 

--- a/docs/adr/002.md
+++ b/docs/adr/002.md
@@ -22,17 +22,15 @@ space, and consists of:
 
 ### Technical story
 
-- [#124](https://github.com/ComPWA/expertsystem/issues/124): see
+- {issue}`ComPWA/expertsystem#124`: see
   {ref}`adr/002:Issues with existing set-up`.
-- [#440](https://github.com/ComPWA/expertsystem/issues/440): no way to supply
-  custom dynamics. Or at least, {mod}`tensorwaves` does not understand those
-  custom dynamics.
+- {issue}`ComPWA/expertsystem#440`: no way to supply custom dynamics. Or at
+  least, {mod}`tensorwaves` does not understand those custom dynamics.
 - [ADR-001](./001.md): parameters _and_ variables are to be expressed as
   `sympy.Symbol`s.
-- [#454](https://github.com/ComPWA/expertsystem/pull/454): dynamics are
-  specified as a mapping of `sympy.Function` to a `sympy.Expr`, but now there
-  is no way to supply those `sympy.Expr`s with expected `sympy.Symbol`s
-  (parameters and variables).
+- {pr}`ComPWA/expertsystem#454`: dynamics are specified as a mapping of
+  `sympy.Function` to a `sympy.Expr`, but now there is no way to supply those
+  `sympy.Expr`s with expected `sympy.Symbol`s (parameters and variables).
 
 ### Issues with existing set-up
 
@@ -240,7 +238,7 @@ We decide to keep responsibilities as separated as possible. This means that:
    expression (`sympy.Expr`) the correct symbol within the complete amplitude
    model. For now, this position is specified using some `StateTransitionGraph`
    and an edge ID, but this syntax may be improved later (see
-   [#458](https://github.com/ComPWA/expertsystem/pull/458)):
+   {pr}`ComPWA/expertsystem#458`):
 
    ```python
    def set_dynamics(

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -27,8 +27,8 @@ Summary of problems with the existing design, possibly with some snippets.
 If available, list and link related issues, PRs, or ADRs that led up to this
 ADR:
 
-- [#000](https://github.com/ComPWA/expertsystem/issues/000)
-- [#000](https://github.com/ComPWA/expertsystem/issues/000)
+- {issue}`000`
+- {issue}`ComPWA/ampform#1`
 -->
 
 ## Decision drivers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
+    "sphinx_issues",
     "sphinx_math_dollar",
     "sphinx_panels",
     "sphinx_thebe",
@@ -208,6 +209,9 @@ modify the parameters.
 """
 }
 myst_update_mathjax = False
+
+# Settings for sphinx-issues
+issues_github_path = "ComPWA/compwa-org"
 
 # Settings for Thebe cell output
 thebe_config = {

--- a/docs/report/000.ipynb
+++ b/docs/report/000.ipynb
@@ -22,7 +22,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report has been implemented in [ComPWA/tensorwaves#284](https://github.com/ComPWA/tensorwaves/pull/284).\n",
+    "This report has been implemented in {pr}`ComPWA/tensorwaves#284`.\n",
     "\n",
     ":::"
    ]

--- a/docs/report/001.ipynb
+++ b/docs/report/001.ipynb
@@ -13,7 +13,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report has been implemented in [ComPWA/ampform#72](https://github.com/ComPWA/ampform/pull/72) and [ComPWA/ampform#284](https://github.com/ComPWA/tensorwaves/pull/284).\n",
+    "This report has been implemented in {pr}`ComPWA/ampform#72` and {pr}`ComPWA/tensorwaves#284`.\n",
     "\n",
     ":::"
    ]

--- a/docs/report/002.ipynb
+++ b/docs/report/002.ipynb
@@ -20,7 +20,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report has been implemented in [ComPWA/tensorwaves#281](https://github.com/ComPWA/tensorwaves/pull/281).\n",
+    "This report has been implemented in {pr}`ComPWA/tensorwaves#281`.\n",
     "\n",
     ":::"
    ]

--- a/docs/report/006.ipynb
+++ b/docs/report/006.ipynb
@@ -63,7 +63,7 @@
     "tags": []
    },
    "source": [
-    "This report illustrates how to interact with [`matplotlib`](https://matplotlib.org) 3D plots through [Matplotlib sliders](https://matplotlib.org/stable/api/widgets_api.html) and [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html). This might be implemented later on in {mod}`symplot` and/or [`mpl_interactions`](https://mpl-interactions.readthedocs.io) (see [ianhi/mpl-interactions#89](https://github.com/ianhi/mpl-interactions/issues/89)).\n",
+    "This report illustrates how to interact with [`matplotlib`](https://matplotlib.org) 3D plots through [Matplotlib sliders](https://matplotlib.org/stable/api/widgets_api.html) and [ipywidgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html). This might be implemented later on in {mod}`symplot` and/or [`mpl_interactions`](https://mpl-interactions.readthedocs.io) (see {issue}`ianhi/mpl-interactions#89`).\n",
     "\n",
     "In this example, we create a surface plot (see {obj}`~mpl_toolkits.mplot3d.Axes3D.plot_surface`) for the following function."
    ]

--- a/docs/report/008.ipynb
+++ b/docs/report/008.ipynb
@@ -32,7 +32,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report has been implemented in [ComPWA/ampform#111](https://github.com/ComPWA/ampform/pull/111).\n",
+    "This report has been implemented in {pr}`ComPWA/ampform#111`.\n",
     "\n",
     ":::\n",
     "\n",

--- a/docs/report/009.ipynb
+++ b/docs/report/009.ipynb
@@ -34,7 +34,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report is a sequel to {doc}`/report/005`. It has been implemented in [ComPWA/ampform#120](https://github.com/ComPWA/ampform/pull/120).\n",
+    "This report is a sequel to {doc}`/report/005`. It has been implemented in {pr}`ComPWA/ampform#120`.\n",
     "\n",
     ":::"
    ]

--- a/docs/report/010.ipynb
+++ b/docs/report/010.ipynb
@@ -36,7 +36,7 @@
    "source": [
     ":::{note}\n",
     "\n",
-    "This report is a sequel to {doc}`/report/005` and {doc}`/report/009`. Has been implemented in [ComPWA/ampform#131](https://github.com/ComPWA/ampform/pull/131)\n",
+    "This report is a sequel to {doc}`/report/005` and {doc}`/report/009`. Has been implemented in {pr}`ComPWA/ampform#131`.\n",
     "\n",
     ":::"
    ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ doc =
     Sphinx >=3
     sphinx-book-theme
     sphinx-copybutton
+    sphinx-issues
     sphinx-math-dollar
     sphinx-panels
     sphinx-thebe


### PR DESCRIPTION
Added [sphinx-issues](https://github.com/sloria/sphinx-issues) as a Sphinx extension, so that it becomes easier to reference issues and pull requests.

```markdown
<!-- old -->
[ComPWA/ampform#166](https://github.com/ComPWA/ampform/issues/166)
[#72](https://github.com/ComPWA/compwa-org/pull/72)
[#65](https://github.com/ComPWA/compwa-org/pull/65), [ComPWA/qrules#59](https://github.com/ComPWA/qrules/issues/59)

<!-- new -->
{issue}`ComPWA/ampform#166`
{pr}`72`
{issue}`65, ComPWA/qrules#59`
```