### PR TITLE
fix: do not evaluate ArrayMultiplication in TR-011

### DIFF
--- a/docs/report/011.ipynb
+++ b/docs/report/011.ipynb
@@ -348,14 +348,9 @@
    },
    "outputs": [],
    "source": [
-    "@implement_doit_method()\n",
-    "class ArrayMultiplication(UnevaluatedExpression):\n",
+    "class ArrayMultiplication(sp.Expr):\n",
     "    def __new__(cls, *tensors: sp.Symbol, **hints: Any):\n",
     "        return create_expression(cls, *tensors, **hints)\n",
-    "\n",
-    "    def evaluate(self) -> sp.Expr:\n",
-    "        tensors = self.args\n",
-    "        return sp.Mul(*tensors)\n",
     "\n",
     "    def _latex(self, printer, *args) -> str:\n",
     "        tensors_latex = map(printer._print, self.args)\n",
@@ -464,9 +459,9 @@
     "def print_as_numpy(self, printer: Printer, *args: Any) -> str:\n",
     "    def multiply(matrix, vector):\n",
     "        return (\n",
-    "            'np.einsum(\"ij...,j...\",'\n",
-    "            f\" np.transpose({matrix}, axes=(1, 2, 0)),\"\n",
-    "            f\" np.transpose({vector}))\"\n",
+    "            'einsum(\"ij...,j...\",'\n",
+    "            f\" transpose({matrix}, axes=(1, 2, 0)),\"\n",
+    "            f\" transpose({vector}))\"\n",
     "        )\n",
     "\n",
     "    def recursive_multiply(tensors):\n",
@@ -476,6 +471,7 @@
     "            return multiply(tensors[0], tensors[1])\n",
     "        return multiply(tensors[0], recursive_multiply(tensors[1:]))\n",
     "\n",
+    "    printer.module_imports[\"numpy\"].update({\"einsum\", \"transpose\"})\n",
     "    tensors = list(map(printer._print, self.args))\n",
     "    if len(tensors) == 0:\n",
     "        return \"\"\n",
@@ -1510,13 +1506,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "compare(\"phi_2+3,1+2+3\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": [
      "raises-exception"
     ]
    },
    "outputs": [],
    "source": [
-    "compare(\"phi_2+3,1+2+3\")"
+    "compare(\"theta_2+3,1+2+3\")"
    ]
   }
  ],


### PR DESCRIPTION
Previously, `ArrayMultiplication` derived from `UnevaluatedExpression` and got a `doit` method implemented. This caused the evaluated expression to use `Mul` instead of `ArrayMultiplication` so that the array contractions were not anymore lambdified to `numpy.einsum`.