### PR TITLE
docs: investigate performance with extended data

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -77,6 +77,7 @@
         "mypy",
         "numpy",
         "parametrizations",
+        "permutate",
         "pylint",
         "pytest",
         "qrules",
@@ -95,6 +96,7 @@
         "Zenodo"
     ],
     "ignoreWords": [
+        "absl",
         "adrs",
         "allclose",
         "appmode",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,6 +196,7 @@ execution_excludepatterns = [
     "report/008*",
     "report/009*",
     "report/010*",
+    "report/012*",
 ]
 nb_output_stderr = "remove"
 nb_render_priority = {

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -58,7 +58,15 @@
      "hide-cell"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install -q ampform==0.12.1 tensorwaves[jax,pwa]==0.4.*"
    ]
@@ -287,7 +295,18 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(100000,)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "intensities = intensity(phsp)\n",
     "extended_intensities = extended_intensity(extended_phsp)\n",
@@ -307,7 +326,16 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14.7 ms ± 761 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n",
+      "14.7 ms ± 669 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
    "source": [
     "%timeit -n10 intensity(phsp)\n",
     "%timeit -n10 extended_intensity(extended_phsp)"
@@ -339,6 +367,7 @@
   }
  ],
  "metadata": {
+  "keep_output": true,
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -64,6 +64,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "{issue}`ComPWA/ampform#198` makes it easier to generate expressions for kinematic variables that are not contained in the [`HelicityModel.expression`](https://ampform.readthedocs.io/en/0.12.1/api/ampform.helicity.html#ampform.helicity.HelicityModel.expression). In TensorWaves, this results in a [`DataSample`](https://tensorwaves.readthedocs.io/en/0.4.x/api/tensorwaves.interface.html#tensorwaves.interface.DataSample) with more keys.\n",
+    "\n",
+    "A question was raised whether this affects the duration of fits. This report shows that this is not the case (see {ref}`report/012:Conclusion`)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -107,6 +116,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Formulate a [`HelicityModel`](https://ampform.readthedocs.io/en/0.12.1/api/ampform.helicity.html#ampform.helicity.HelicityModel) just like in the [usual workflow](https://ampform.readthedocs.io/en/0.12.1/usage/amplitude.html):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -131,7 +147,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now register more topologies with [`HelicityAdapter.permutate_registered_topologies()`](https://ampform.readthedocs.io/en/0.12.1/api/ampform.kinematics.html#ampform.kinematics.HelicityAdapter.permutate_registered_topologies) and formulate a new 'extended' model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder.adapter.permutate_registered_topologies()\n",
+    "extended_model = builder.formulate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create computational functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, create [`ParametrizedFunction`](https://tensorwaves.readthedocs.io/en/0.4.x/api/tensorwaves.interface.html#tensorwaves.interface.ParametrizedFunction)s for the normal model and the extended model:"
    ]
   },
   {
@@ -151,21 +191,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create a new model with more registered topologies:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "builder.adapter.permutate_registered_topologies()\n",
-    "extended_model = builder.formulate()\n",
-    "\n",
     "extended_intensity = create_parametrized_function(\n",
     "    expression=extended_model.expression.doit(),\n",
     "    parameters=extended_model.parameter_defaults,\n",
@@ -254,11 +284,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "intensities = intensity(phsp)\n",
-    "extended_intensities = extended_intensity(extended_phsp)"
+    "extended_intensities = extended_intensity(extended_phsp)\n",
+    "extended_intensities.shape"
    ]
   },
   {
@@ -271,7 +304,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%timeit -n10 intensity(phsp)\n",
@@ -282,13 +317,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Output arrays are the same:"
+    "Output arrays are also the same:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "np.testing.assert_allclose(intensities, extended_intensities)\n",

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -85,7 +85,6 @@
     "    create_non_dynamic_with_ff,\n",
     "    create_relativistic_breit_wigner_with_ff,\n",
     ")\n",
-    "\n",
     "from tensorwaves.data import (\n",
     "    IntensityDistributionGenerator,\n",
     "    SympyDataTransformer,\n",

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -60,7 +60,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q ampform==0.12.1 tensorwaves[pwa]==0.4.*"
+    "%pip install -q ampform==0.12.1 tensorwaves[jax,pwa]==0.4.*"
    ]
   },
   {

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hideCode": true,
+    "hideOutput": true,
+    "hidePrompt": true,
+    "jupyter": {
+     "source_hidden": true
+    },
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "%config Completer.use_jedi = False\n",
+    "%config InlineBackend.figure_formats = ['svg']\n",
+    "import os\n",
+    "\n",
+    "STATIC_WEB_PAGE = {\"EXECUTE_NB\", \"READTHEDOCS\"}.intersection(os.environ)\n",
+    "\n",
+    "# Install on Google Colab\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "from IPython import get_ipython\n",
+    "\n",
+    "install_packages = \"google.colab\" in str(get_ipython())\n",
+    "if install_packages:\n",
+    "    for package in [\"tensorwaves[doc]\", \"graphviz\"]:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", package]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [TR-012] Extended `DataSample` performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q ampform==0.12.1 tensorwaves[pwa]==0.4.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "import ampform\n",
+    "import numpy as np\n",
+    "import qrules\n",
+    "from ampform.dynamics.builder import (\n",
+    "    create_non_dynamic_with_ff,\n",
+    "    create_relativistic_breit_wigner_with_ff,\n",
+    ")\n",
+    "\n",
+    "from tensorwaves.data import (\n",
+    "    IntensityDistributionGenerator,\n",
+    "    SympyDataTransformer,\n",
+    "    TFPhaseSpaceGenerator,\n",
+    "    TFUniformRealNumberGenerator,\n",
+    ")\n",
+    "from tensorwaves.function.sympy import create_parametrized_function\n",
+    "\n",
+    "LOGGER = logging.getLogger(\"absl\")\n",
+    "LOGGER.setLevel(logging.ERROR)\n",
+    "LOGGER = logging.getLogger()\n",
+    "LOGGER.setLevel(logging.ERROR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate amplitude model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction = qrules.generate_transitions(\n",
+    "    initial_state=(\"J/psi(1S)\", [-1, +1]),\n",
+    "    final_state=[\"gamma\", \"pi0\", \"pi0\"],\n",
+    "    allowed_intermediate_particles=[\"f(0)\"],\n",
+    "    allowed_interaction_types=[\"strong\", \"EM\"],\n",
+    "    formalism=\"helicity\",\n",
+    ")\n",
+    "\n",
+    "builder = ampform.get_builder(reaction)\n",
+    "builder.set_dynamics(\"J/psi(1S)\", create_non_dynamic_with_ff)\n",
+    "for name in reaction.get_intermediate_particles().names:\n",
+    "    builder.set_dynamics(name, create_relativistic_breit_wigner_with_ff)\n",
+    "model = builder.formulate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create computational functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intensity = create_parametrized_function(\n",
+    "    expression=model.expression.doit(),\n",
+    "    parameters=model.parameter_defaults,\n",
+    "    backend=\"jax\",\n",
+    ")\n",
+    "helicity_transformer = SympyDataTransformer.from_sympy(\n",
+    "    model.kinematic_variables, backend=\"jax\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new model with more registered topologies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder.adapter.permutate_registered_topologies()\n",
+    "extended_model = builder.formulate()\n",
+    "\n",
+    "extended_intensity = create_parametrized_function(\n",
+    "    expression=extended_model.expression.doit(),\n",
+    "    parameters=extended_model.parameter_defaults,\n",
+    "    backend=\"jax\",\n",
+    ")\n",
+    "extended_helicity_transformer = SympyDataTransformer.from_sympy(\n",
+    "    extended_model.kinematic_variables, backend=\"jax\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate phase space domain and hit-and-miss data sample with the normal intensity function and helicity transformer..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phsp_generator = TFPhaseSpaceGenerator(\n",
+    "    initial_state_mass=reaction.initial_state[-1].mass,\n",
+    "    final_state_masses={i: p.mass for i, p in reaction.final_state.items()},\n",
+    ")\n",
+    "data_generator = IntensityDistributionGenerator(\n",
+    "    function=intensity,\n",
+    "    domain_generator=phsp_generator,\n",
+    "    domain_transformer=helicity_transformer,\n",
+    ")\n",
+    "rng = TFUniformRealNumberGenerator(seed=0)\n",
+    "phsp_momenta = phsp_generator.generate(100_000, rng)\n",
+    "data_momenta = data_generator.generate(10_000, rng)\n",
+    "phsp = helicity_transformer(phsp_momenta)\n",
+    "data = helicity_transformer(data_momenta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "...and with the extended function and transformer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extended_phsp_generator = TFPhaseSpaceGenerator(\n",
+    "    # actually same as phsp_generator\n",
+    "    initial_state_mass=reaction.initial_state[-1].mass,\n",
+    "    final_state_masses={i: p.mass for i, p in reaction.final_state.items()},\n",
+    ")\n",
+    "extended_data_generator = IntensityDistributionGenerator(\n",
+    "    function=extended_intensity,\n",
+    "    domain_generator=phsp_generator,\n",
+    "    domain_transformer=helicity_transformer,\n",
+    ")\n",
+    "rng = TFUniformRealNumberGenerator(seed=0)\n",
+    "phsp_momenta = extended_phsp_generator.generate(100_000, rng)\n",
+    "data_momenta = extended_data_generator.generate(10_000, rng)\n",
+    "extended_phsp = extended_helicity_transformer(phsp_momenta)\n",
+    "extended_data = extended_helicity_transformer(data_momenta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intensities = intensity(phsp)\n",
+    "extended_intensities = extended_intensity(extended_phsp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Computation time per iteration is the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit -n10 intensity(phsp)\n",
+    "%timeit -n10 extended_intensity(extended_phsp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Output arrays are the same:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_allclose(intensities, extended_intensities)\n",
+    "\n",
+    "assert set(data) < set(extended_data)\n",
+    "assert set(phsp) < set(extended_phsp)\n",
+    "for var in data:\n",
+    "    np.testing.assert_allclose(phsp[var], extended_phsp[var])\n",
+    "    np.testing.assert_allclose(data[var], extended_data[var])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
https://github.com/ComPWA/ampform/pull/198 makes it easier to generate expressions for kinematic variables that are not contained in the `HelicityModel.expression`. In TensorWaves, this results in a `DataSample` with more keys. A question was raised whether this affects the duration of fits. TR-012 shows that this is not the case.