### PR TITLE
fix: remove redundant autolink-skip

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,6 +15,7 @@ vscode:
   extensions:
     - bungcip.better-toml
     - christian-kohler.path-intellisense
+    - cschleiden.vscode-github-actions
     - davidanson.vscode-markdownlint
     - eamodio.gitlens
     - editorconfig.editorconfig

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,10 +49,6 @@ repos:
       - id: fix-nbformat-version
       - id: format-setup-cfg
       - id: pin-nb-requirements
-        exclude: >
-          (?x)^(
-            docs/report/007.*
-          )$
       - id: set-nb-cells
 
   - repo: https://github.com/psf/black

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "bungcip.better-toml",
     "christian-kohler.path-intellisense",
+    "cschleiden.vscode-github-actions",
     "davidanson.vscode-markdownlint",
     "eamodio.gitlens",
     "editorconfig.editorconfig",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,13 +27,13 @@
     "**/.tox/**": true
   },
   "git.rebaseWhenSync": true,
-  "githubPullRequests.telemetry.enabled": false,
-  "gitlens.advanced.telemetry.enabled": false,
-  "markdown.extension.italic.indicator": "_",
+  "github-actions.workflows.pinned.workflows": [
+    ".github/workflows/ci-docs.yml",
+    ".github/workflows/linkcheck.yml"
+  ],
   "python.analysis.autoImportCompletions": false,
   "python.analysis.diagnosticMode": "workspace",
   "python.formatting.provider": "black",
-  "python.languageServer": "Pylance",
   "python.linting.banditEnabled": false,
   "python.linting.enabled": true,
   "python.linting.flake8Enabled": true,
@@ -42,7 +42,6 @@
   "python.linting.pylamaEnabled": false,
   "python.linting.pylintCategorySeverity.refactor": "Information",
   "python.linting.pylintEnabled": true,
-  "python.linting.pylintUseMinimalCheckers": false,
   "python.testing.pytestEnabled": false,
   "rewrap.wrappingColumn": 79,
   "search.exclude": {
@@ -50,6 +49,5 @@
     "*/.pydocstyle": true,
     ".constraints/*.txt": true
   },
-  "telemetry.enableCrashReporter": false,
-  "telemetry.enableTelemetry": false
+  "telemetry.telemetryLevel": "off"
 }

--- a/docs/adr/001/operators.ipynb
+++ b/docs/adr/001/operators.ipynb
@@ -32,14 +32,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/adr/001/sympy.ipynb
+++ b/docs/adr/001/sympy.ipynb
@@ -25,14 +25,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/adr/002/composition.ipynb
+++ b/docs/adr/002/composition.ipynb
@@ -25,14 +25,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/adr/002/expr.ipynb
+++ b/docs/adr/002/expr.ipynb
@@ -25,14 +25,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/adr/002/function.ipynb
+++ b/docs/adr/002/function.ipynb
@@ -25,14 +25,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,7 @@ html_theme_options = {
         "thebe": True,
         "thebelab": True,
     },
+    "show_toc_level": 2,
 }
 html_title = "Common Partial Wave Analysis Project"
 panels_add_bootstrap_css = False  # wider pages

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -565,21 +565,17 @@ statuses, et cetera with GitHub project boards
 are:
 
 - [Public roadmap](https://github.com/orgs/ComPWA/projects/4)
-- [Development planning](https://github.com/orgs/ComPWA/projects/5) [private]
-- [Infrastructure & Maintenance](https://github.com/orgs/ComPWA/projects/6)
-  [private]
+- [Development planning](https://github.com/orgs/ComPWA/projects/5)
 
-Some boards are not public. To get access, you can request to become member of
+Some issues are not public. To get access, you can request to become member of
 the [ComPWA](https://github.com/ComPWA) GitHub organization. Other information
 that is publicly available are:
 
 - [Issue labels](https://github.com/ComPWA/ampform/labels): help to categorize
   issues by type (maintenance, enhancement, bug, etc.). The labels are also
   used to in the sub-sections of the release notes.
-
 - [Milestones](https://github.com/ComPWA/ampform/milestones?direction=asc&sort=title&state=open):
   way to bundle issues and PRs for upcoming releases.
-
 - [Releases](https://github.com/ComPWA/ampform/releases).
 
 All of these are important for the {ref}`develop:Release flow` and therefore

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -174,15 +174,15 @@ each version of Python that the package supports.
 :::
 
 ```shell
-python3 -m pip install -c .constraints/py-3.8.txt -e .
+python3 -m pip install -c .constraints/py3.8.txt -e .
 ```
 
 The syntax works just as well for {ref}`develop:Optional dependencies`:
 
 ```shell
-python3 -m pip install -c .constraints/py-3.8.txt -e .[doc,sty]
-python3 -m pip install -c .constraints/py-3.8.txt -e .[test]
-python3 -m pip install -c .constraints/py-3.8.txt -e .[dev]
+python3 -m pip install -c .constraints/py3.8.txt -e .[doc,sty]
+python3 -m pip install -c .constraints/py3.8.txt -e .[test]
+python3 -m pip install -c .constraints/py3.8.txt -e .[dev]
 ```
 
 The constraint files are updated automatically with

--- a/docs/report/000.ipynb
+++ b/docs/report/000.ipynb
@@ -68,14 +68,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/001.ipynb
+++ b/docs/report/001.ipynb
@@ -53,16 +53,8 @@
     "```\n",
     "````\n",
     "\n",
-    "# Custom lambdification"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<!-- cspell:disable -->\n",
-    "```{autolink-skip}\n",
-    "```"
+    "# Custom lambdification\n",
+    "<!-- cspell:disable -->"
    ]
   },
   {

--- a/docs/report/002.ipynb
+++ b/docs/report/002.ipynb
@@ -58,14 +58,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/003.ipynb
+++ b/docs/report/003.ipynb
@@ -59,14 +59,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -80,14 +72,6 @@
    "outputs": [],
    "source": [
     "%pip install -q ampform==0.13.3 black==22.3.0 matplotlib==3.5.1 mpl-interactions==0.20.2 numpy==1.22.3 qrules==0.9.7 sympy==1.10.1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
    ]
   },
   {
@@ -114,20 +98,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
+    "tags": [
+     "remove-input"
+    ]
    },
    "outputs": [],
    "source": [

--- a/docs/report/004.ipynb
+++ b/docs/report/004.ipynb
@@ -60,14 +60,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -84,22 +76,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
-     "remove-cell"
+     "remove-input"
     ]
    },
    "outputs": [],

--- a/docs/report/005.ipynb
+++ b/docs/report/005.ipynb
@@ -71,14 +71,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -95,22 +87,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
-     "remove-cell"
+     "remove-input"
     ]
    },
    "outputs": [],

--- a/docs/report/006.ipynb
+++ b/docs/report/006.ipynb
@@ -51,14 +51,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -82,18 +74,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": [
+     "remove-input"
+    ]
    },
    "outputs": [],
    "source": [

--- a/docs/report/007.ipynb
+++ b/docs/report/007.ipynb
@@ -56,24 +56,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
-     "hide-cell"
+     "remove-cell"
     ]
    },
    "outputs": [],
    "source": [
-    "%pip -q install sympy==1.9"
+    "%pip install -q sympy==1.9"
    ]
   },
   {

--- a/docs/report/008.ipynb
+++ b/docs/report/008.ipynb
@@ -53,14 +53,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/009.ipynb
+++ b/docs/report/009.ipynb
@@ -52,14 +52,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -139,22 +131,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
-     "remove-cell"
+     "remove-input"
     ]
    },
    "outputs": [],

--- a/docs/report/010.ipynb
+++ b/docs/report/010.ipynb
@@ -54,14 +54,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -78,22 +70,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
-     "remove-cell"
+     "remove-input"
     ]
    },
    "outputs": [],

--- a/docs/report/011.ipynb
+++ b/docs/report/011.ipynb
@@ -53,14 +53,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/012.ipynb
+++ b/docs/report/012.ipynb
@@ -49,14 +49,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/013.ipynb
+++ b/docs/report/013.ipynb
@@ -52,15 +52,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<!-- cspell:ignore phasespace -->\n",
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/014.ipynb
+++ b/docs/report/014.ipynb
@@ -52,14 +52,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/015.ipynb
+++ b/docs/report/015.ipynb
@@ -54,14 +54,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/docs/report/016.ipynb
+++ b/docs/report/016.ipynb
@@ -59,14 +59,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{autolink-skip}\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {


### PR DESCRIPTION
Follow-up to #131, which removes the rendering of `%pip install` cells on the static pages, but did not remove the `autolink-skip` directive. Consequence was that the cell with `import` statements was not linked with [`sphinx-codeautolink`](https://sphinx-codeautolink.rtfd.io).

_Note: this PR was extracted from #129 in order to reduce its diff._