### PR TITLE
fix: install TensorWaves v0.2.9 in TR-002

### DIFF
--- a/docs/report/002.ipynb
+++ b/docs/report/002.ipynb
@@ -70,7 +70,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q ampform==0.9.1 numpy==1.19.5 pandas==1.2.4 pandas==1.2.4 qrules==0.8.2 sympy==1.8 tensorwaves==0.2.9 git+https://github.com/zfit/phasespace@7131fbd"
+    "%pip install -q ampform==0.9.1 numpy==1.19.5 pandas==1.2.4 pandas==1.2.4 qrules==0.8.2 sympy==1.8 tensorwaves[jax]==0.2.9 git+https://github.com/zfit/phasespace@7131fbd"
    ]
   },
   {


### PR DESCRIPTION
Follow-up to #153 that fixes this problem:
https://github.com/ComPWA/compwa-org/runs/6795134635?check_suite_focus=true#step:5:141

See also [TensorWaves v0.2.9](https://github.com/ComPWA/tensorwaves/releases/tag/0.2.9).

_Update: all notebooks can now [indeed be run from GitHub Actions](https://github.com/ComPWA/compwa-org/actions/runs/2464047079)._