### PR TITLE
DOC: improve documentation sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,19 @@ html_sourcelink_suffix = ""
 html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
 html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": f"https://github.com/ComPWA",
+            "icon": "fa-brands fa-github",
+        },
+        {
+            "name": "Zenodo",
+            "url": "https://doi.org/10.5281/zenodo.6908149",
+            "icon": "https://zenodo.org/badge/DOI/10.5281/zenodo.6908149.svg",
+            "type": "url",
+        },
+    ],
     "logo": {"text": "The ComPWA project"},
     "repository_url": f"https://github.com/ComPWA/{REPO_NAME}",
     "repository_branch": BRANCH,

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,7 @@
 ```
 
 <!-- prettier-ignore-start -->
-[![10.5281/zenodo.6908149](https://zenodo.org/badge/DOI/10.5281/zenodo.6908149.svg)](https://doi.org/10.5281/zenodo.6908149)
-{{ '[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ComPWA/compwa-org/blob/{})'.format(branch) }}
-{{ '[![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ComPWA/compwa-org/{}?filepath=docs/usage)'.format(branch) }}
+{{ '[![Google Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ComPWA/compwa-org/blob/{})'.format(branch) }} {{ '[![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ComPWA/compwa-org/{}?filepath=docs/usage)'.format(branch) }}
 <!-- prettier-ignore-end -->
 
 The ["Common Partial Wave Analysis"](https://github.com/ComPWA) organization (ComPWA)


### PR DESCRIPTION
#189 upgraded `sphinx-book-theme` to v1.0.0, which requires some additional configuration to:
- get the package title back in the sidebar
- add mini-logo's in the sidebar
![image](https://user-images.githubusercontent.com/29308176/229134055-e25cb6c2-4f83-41fe-bc84-568f8fc30312.png)
