### PR TITLE
FIX: remove `size` argument from `sp.dotprint`

### DIFF
--- a/docs/report/024.ipynb
+++ b/docs/report/024.ipynb
@@ -589,7 +589,7 @@
     "    (sp.Symbol, {\"color\": \"dodgerblue1\"}),\n",
     "    (PhspFactorSWave, {\"color\": \"indianred2\"}),\n",
     "]\n",
-    "dot = sp.dotprint(BW_expr, bgcolor=None, size=10, styles=dot_style)\n",
+    "dot = sp.dotprint(BW_expr, bgcolor=None, styles=dot_style)\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -623,7 +623,7 @@
    },
    "outputs": [],
    "source": [
-    "dot = sp.dotprint(BW_expr.doit(), bgcolor=None, size=10, styles=dot_style)\n",
+    "dot = sp.dotprint(BW_expr.doit(), bgcolor=None, styles=dot_style)\n",
     "graphviz.Source(dot)"
    ]
   },


### PR DESCRIPTION
With the `size` argumnent, the resulting figure looks weird on the Sphinx build:

![image](https://github.com/ComPWA/compwa-org/assets/29308176/36c9bd03-f5e8-42b3-8913-c49d07b80a83)
