### PR TITLE
DOC: add links to Git tutorials

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -708,7 +708,13 @@ and developer set-up with GitHub issues (see for instance
 
 :::{tip}
 If you are new to working with GitHub, have a look at the tutorials on
-[GitHub Skills](https://skills.github.com).
+[GitHub Skills](https://skills.github.com). For good tutorials on Git, see:
+
+- [freeCodeCamp's "Gitting Things Done"](https://www.freecodecamp.org/news/gitting-things-done-book)
+  <!-- cspell:ignore gitting -->
+- [HSF Software Training Center](https://swcarpentry.github.io/git-novice)
+- The [Pro Git](https://git-scm.com/book/en/v2) book
+
 :::
 
 ### Issue management


### PR DESCRIPTION
> For good tutorials on Git, see:
> - [freeCodeCamp's "Gitting Things Done"](https://www.freecodecamp.org/news/gitting-things-done-book)
> - [HSF Software Training Center](https://swcarpentry.github.io/git-novice)
> - The [Pro Git](https://git-scm.com/book/en/v2) book